### PR TITLE
:memo:(n8n-node): Fix some documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </div>
 <!-- trunk-ignore-end(markdownlint/MD033) -->
 
-+This is a n8n community node. It lets you use [Paperless-ngx](https://docs.paperless-ngx.com/) in your n8n workflows.  
+This is a n8n community node. It lets you use [Paperless-ngx](https://docs.paperless-ngx.com/) in your n8n workflows.
 
 Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive so you can keep your paper documents, but lose the cabinet.
 
@@ -25,7 +25,7 @@ Paperless-ngx is a document management system that transforms your physical docu
 Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes/installation/) in the n8n community nodes documentation.
 
 > [!NOTE]
-> This node requires the `form-data` package for handling multipart/form-data requests. It will be automatically installed as a dependency if not already present in your n8n installation.  
+> This node requires the `form-data` package for handling multipart/form-data requests. It will be automatically installed as a dependency if not already present in your n8n installation.
 
 ## Operations
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,6 +10,9 @@ print("""
 -----------------------------------------------------------------
 """.strip())
 
+# Configure Docker pruning to prevent disk space issues
+# - Keeps only 5 builds in total
+# - Preserves the 2 most recent builds
 docker_prune_settings(num_builds=5, keep_recent=2)
 
 docker_compose('./.devcontainer/docker-compose.yaml')


### PR DESCRIPTION
Signed-off-by: Alexandre NICOLAIE <alexandre.nicolaie@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Minor spacing adjustments in README.md

- **Chores**
  - Updated Tiltfile with Docker pruning configuration to manage build images (retaining 5 builds, keeping 2 most recent)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->