### PR TITLE
:sparkles:(n8n-node): Add option to append tags in document update operation

### DIFF
--- a/nodes/Paperless/v2/actions/document/update.operation.ts
+++ b/nodes/Paperless/v2/actions/document/update.operation.ts
@@ -86,6 +86,14 @@ export const description: INodeProperties[] = [
 		placeholder: 'Add Field',
 		options: [
 			{
+				displayName: 'Append Tags',
+				name: 'append_tags',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to append the new tags to the existing ones instead of replacing them',
+			},
+			{
 				displayName: 'Archive Serial Number',
 				name: 'archive_serial_number',
 				default: '',
@@ -339,6 +347,14 @@ export async function execute(
 
 	const updateFields = this.getNodeParameter('update_fields', itemIndex, {}) as any;
 
+	let tags = updateFields.tags?.values.map((tag: any) => Number(tag.tag.value));
+
+	if (updateFields.append_tags && tags && tags.length > 0) {
+		const currentDocument = (await apiRequest.call(this, itemIndex, 'GET', endpoint)) as any;
+		const currentTags = (currentDocument.tags || []).map((t: any) => Number(t));
+		tags = [...new Set([...currentTags, ...tags])];
+	}
+
 	const body = {
 		archive_serial_number: updateFields.archive_serial_number,
 		correspondent: updateFields.correspondent?.value,
@@ -349,7 +365,7 @@ export async function execute(
 		})),
 		document_type: updateFields.document_type?.value,
 		storage_path: updateFields.storage_path?.value,
-		tags: updateFields.tags?.values.map((tag: any) => tag.tag.value),
+		tags,
 		title: updateFields.title,
 	};
 


### PR DESCRIPTION
This pull request adds support for appending new tags to existing ones when updating a document in the Paperless node, instead of always replacing them. The main changes introduce a new boolean option and update the tag handling logic accordingly.

Enhancements to tag updating functionality:

* Added a new boolean field `append_tags` to the update document operation, allowing users to choose whether to append new tags to the existing tags or replace them.
* Modified the tag update logic in the `execute` function to merge new tags with existing ones if `append_tags` is true, ensuring no duplicates. [[1]](diffhunk://#diff-2e10f77cc18c2b19bef940a0a7555bd5b8908ddeed308db5c9a026d69fb222cbR350-R357) [[2]](diffhunk://#diff-2e10f77cc18c2b19bef940a0a7555bd5b8908ddeed308db5c9a026d69fb222cbL352-R368)

Closes #15 