### PR TITLE
fix(document): use n8n native formData format for document upload

### DIFF
--- a/nodes/Paperless/v2/actions/document/create.operation.ts
+++ b/nodes/Paperless/v2/actions/document/create.operation.ts
@@ -1,4 +1,3 @@
-import FormData from 'form-data';
 import { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
@@ -179,17 +178,22 @@ export async function execute(
 	itemIndex: number,
 ): Promise<INodeExecutionData> {
 	const endpoint = `/documents/post_document/`;
-	const formData = new FormData();
 
 	const binaryPropertyName = this.getNodeParameter('binary_property_name', itemIndex) as string;
 	const binaryData = this.helpers.assertBinaryData(itemIndex, binaryPropertyName);
 	const data = binaryData.id
 		? await this.helpers.getBinaryStream(binaryData.id)
 		: Buffer.from(binaryData.data, 'base64');
-	formData.append('document', data, {
-		filename: binaryData.fileName,
-		contentType: binaryData.mimeType,
-	});
+
+	const formData: Record<string, unknown> = {
+		document: {
+			value: data,
+			options: {
+				filename: binaryData.fileName,
+				contentType: binaryData.mimeType,
+			},
+		},
+	};
 
 	const additionalFields = this.getNodeParameter('additional_fields', itemIndex) as any;
 	Object.entries({
@@ -202,7 +206,7 @@ export async function execute(
 	})
 		.filter(([, value]) => value !== undefined && value !== '')
 		.forEach(([key, value]) => {
-			formData.append(key, value);
+			formData[key] = String(value);
 		});
 
 	const response = (await apiRequest.call(
@@ -212,8 +216,7 @@ export async function execute(
 		endpoint,
 		undefined,
 		undefined,
-		{ headers: formData.getHeaders(), formData },
-		// { body },
+		{ formData },
 	)) as any;
 
 	return { json: { results: [response] } };

--- a/package.json
+++ b/package.json
@@ -59,9 +59,7 @@
 	"peerDependencies": {
 		"n8n-workflow": "*"
 	},
-	"dependencies": {
-		"form-data": "^4.0.1"
-	},
+	"dependencies": {},
 	"bugs": {
 		"url": "https://github.com/chezmoi-sh/n8n-nodes-paperless-ngx/issues"
 	}


### PR DESCRIPTION
## Problem

The `create` operation for documents was timing out with a `499 Client Closed Request` error. Every upload attempt took exactly 60 seconds before failing.

## Root Cause

The operation used the `form-data` npm package to build a multipart request body, then passed the `FormData` instance directly as the `formData` option to n8n's `requestWithAuthentication` helper:

```typescript
const formData = new FormData();
formData.append('document', data, { filename, contentType });
// ...
await apiRequest.call(this, ..., { headers: formData.getHeaders(), formData });
```

n8n's HTTP client does **not** accept a `form-data` instance as the `formData` option. It expects a plain object with the shape:

```typescript
{
  fieldName: {
    value: Buffer | Stream,
    options: { filename: string, contentType: string }
  }
}
```

Passing a `FormData` stream instance caused n8n to be unable to serialize the request body correctly, resulting in the connection hanging until the client's 60-second timeout fired.

## Fix

- Replace the `form-data` npm package usage with n8n's native `formData` plain-object format
- Remove the `form-data` package from `dependencies` (no longer needed)

## Testing

Verified on a self-hosted n8n instance with paperless-ngx. Document upload now completes successfully in ~100ms instead of timing out.